### PR TITLE
Refactor fasta_chunker using line.strip and direct iteration

### DIFF
--- a/codon_usage_calculator.py
+++ b/codon_usage_calculator.py
@@ -137,8 +137,8 @@ class CdsManager:
 
         return ids_for_non_redundant_sequences
 
-        @staticmethod
-        def fasta_chunker(fasta_path: Path) -> Iterator[list[str]]:
+    @staticmethod
+    def fasta_chunker(fasta_path: Path) -> Iterator[list[str]]:
         fasta_seq = []
         first_chunk = True
         with fasta_path.open() as inhandle:

--- a/codon_usage_calculator.py
+++ b/codon_usage_calculator.py
@@ -137,20 +137,13 @@ class CdsManager:
 
         return ids_for_non_redundant_sequences
 
-    @staticmethod
-    def fasta_chunker(fasta_path: Path) -> Iterator[list[str]]:
+        @staticmethod
+        def fasta_chunker(fasta_path: Path) -> Iterator[list[str]]:
         fasta_seq = []
         first_chunk = True
         with fasta_path.open() as inhandle:
-            reader_iterator = reader(inhandle)
-            for line in reader_iterator:
-                try:
-                    line = line[0]
-                except IndexError:
-                    if len(line) == 0:
-                        continue
-                    else:
-                        raise Exception
+            for line in inhandle:
+                line = line.strip()
                 if not line.startswith(">"):
                     fasta_seq.append(line)
                 else:


### PR DESCRIPTION
This PR replaces the previous use of csv.reader with line.strip(). No need of pulling line[0].